### PR TITLE
Update crate dependencies / fix Windows build failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,38 +16,38 @@ name = "bench_scraper"
 path = "src/lib.rs"
 
 [dependencies]
-aes = "0.8.2"
-aes-gcm = "0.10.1"
-base64 = "0.13.1"
-block-padding = "0.3.2"
+aes = "0.8.4"
+aes-gcm = "0.10.3"
+base64 = "0.22.1"
+block-padding = "0.3.3"
 cbc = "0.1.2"
-dirs = "4.0.0"
+dirs = "5.0.1"
 json_dotpath = "1.1.0"
-libsqlite3-sys = "0.25.2"
-log = "0.4.17"
-nom = "7.1.1"
-pbkdf2 = { version = "0.11.0", features = ["sha1"] }
-reqwest = { version = "0.11.0", default-features = false, features = ["cookies"], optional = true }
-rusqlite = { version = "0.28.0", features = ["bundled"] }
-serde = "1.0.147"
-serde_json = "1.0.87"
-strum = "0.24.1"
-strum_macros = "0.24"
-tempfile = "3.3.0"
-time = { version = "0.3.15", features = ["formatting"] }
-walkdir = "2.3.2"
+libsqlite3-sys = "0.28.0"
+log = "0.4.21"
+nom = "7.1.3"
+pbkdf2 = { version = "0.12.2", features = ["sha1", "simple"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["cookies"], optional = true }
+rusqlite = { version = "0.31.0", features = ["bundled"] }
+serde = "1.0.201"
+serde_json = "1.0.117"
+strum = "0.26.2"
+strum_macros = "0.26.2"
+tempfile = "3.10.1"
+time = { version = "0.3.36", features = ["formatting"] }
+walkdir = "2.5.0"
 
 [dev-dependencies]
 bench_scraper = { path = ".", features = ["reqwest"] }
-csv = "1.1.6"
-regex = "1.7.0"
-reqwest = { version = "0.11.0", default-features = false, features = ["blocking", "cookies", "default-tls"] }
+csv = "1.3.0"
+regex = "1.10.4"
+reqwest = { version = "0.12.4", default-features = false, features = ["blocking", "cookies", "default-tls"] }
 
 [target.'cfg(target_os="linux")'.dependencies]
-secret-service = "2.0.2"
+secret-service = { version = "3.0.1", features = ["rt-tokio-crypto-rust"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
-winapi = { version = "0.3.9", features = ["dpapi"] }
+winapi = { version = "0.3.9", features = ["dpapi", "winbase"] }
 
 [features]
 reqwest = ["dep:reqwest"]


### PR DESCRIPTION
The bench_scraper crate doesn't currently build on Windows, due to changes in the winapi crate. For an example build failure, see 

   https://github.com/emarsden/dash-mpd-cli/actions/runs/9019338907/job/24781991395

This patch updates the dependent crates and adapts to API changes when necessary. In particular, move to a new version of the secret_service crate, which has moved to async-by-default queries, a new version of the winapi crate which has moved winbase behind a "winbase" feature flag, and a new version of the pbkdf2 crate which has moved some functionality behind a "simple" feature flag.